### PR TITLE
typo: twtich -> twitch

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,4 +1,4 @@
 export TWITCH_CLIENT_ID=""
-export TWTICH_TOKEN=""
-export TWTICH_CHANNEL="#someuser"
+export TWITCH_TOKEN=""
+export TWITCH_CHANNEL="#someuser"
 export TWITCH_USER="someuser"

--- a/twitch-doom.py
+++ b/twitch-doom.py
@@ -14,8 +14,8 @@ import os
 class TwitchBot(irc.bot.SingleServerIRCBot):
     def __init__(self):
         self.client_id = os.environ['TWITCH_CLIENT_ID']
-        self.token = os.environ['TWTICH_TOKEN']
-        self.channel = os.environ['TWTICH_CHANNEL']
+        self.token = os.environ['TWITCH_TOKEN']
+        self.channel = os.environ['TWITCH_CHANNEL']
         self.user= os.environ['TWITCH_USER']
         rd_port = 6666
         rd_host = "http://localhost"


### PR DESCRIPTION
This pull request just fixes a minor typo (the environment variables contained "twtich" instead of "twitch").

Thx